### PR TITLE
Fixes grid direction for i/jScansPositively == 0,

### DIFF
--- a/pygrib.pyx
+++ b/pygrib.pyx
@@ -1682,6 +1682,11 @@ cdef class gribmessage(object):
             dy = self['DyInMetres']
             pj = pyproj.Proj(self.projparams)
             llcrnrx, llcrnry = pj(lon1,lat1)
+            # Set increment direction here for the grid.
+            # NOTE: some GRIB files are arranged with first gridpoint
+            # in top left, or top right corner for example...
+            if self['iScansPositively'] == 0: dx = -dx
+            if self['jScansPositively'] == 0: dy = -dy
             x = llcrnrx+dx*np.arange(nx)
             y = llcrnry+dy*np.arange(ny)
             x, y = np.meshgrid(x, y)


### PR DESCRIPTION
for now only applied to the 'lambert' projection in latlons() method.

Changes to be committed:
	modified:   pygrib.pyx